### PR TITLE
Resolve per thread cache size for readers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ crossbeam-utils = "0.7"
 parking_lot = "0.10"
 num = "0.2.0"
 smallvec = "1.2"
+lru = "0.4"
 
 [dev-dependencies]
 time = "0.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@
 #![warn(missing_docs)]
 
 extern crate crossbeam_epoch;
+extern crate lru;
 extern crate parking_lot;
 extern crate smallvec;
 


### PR DESCRIPTION
This adds a per-thread reader lru with a min size of 8, to help prevent memory exhaustion of readers if a full scan of the db occurs in those operations. 

Writers can not have this due to items in the writer being potentially dirty, so we need to keep that set as unbounded, but writers tend to not be vulnerable to scanning attacks. 